### PR TITLE
fix: allow usage of args proc macro from other repos

### DIFF
--- a/osquery-rust-codegen/Cargo.toml
+++ b/osquery-rust-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osquery-rust-codegen"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Tobias Mucke <tobias.mucke@gmail.com>",
 ]

--- a/osquery-rust-codegen/src/lib.rs
+++ b/osquery-rust-codegen/src/lib.rs
@@ -1,6 +1,5 @@
 use proc_macro::TokenStream;
 
-use std::fs;
 use std::str::FromStr;
 
 /// Defines a CLI for an osquery-rust based extension which is compliant to osquery interface.
@@ -18,9 +17,7 @@ use std::str::FromStr;
 #[proc_macro_attribute]
 pub fn args(_attr: TokenStream, input: TokenStream) -> TokenStream {
     //todo: error handling!
-    let s = fs::read_to_string("osquery-rust-codegen/src/cli.rs").unwrap();
-    let mut output: TokenStream = TokenStream::from_str(s.as_ref()).unwrap();
-
+    let mut output = TokenStream::from_str(include_str!("cli.rs")).unwrap();
     output.extend(input);
     output
 }


### PR DESCRIPTION
When the proc macro is derived in another repo, reading the file fails, because it's not read relative to the source file, but relative to the working directory. This can be fixed by using the `include_str` macro instead.
