### PR TITLE
Introduce devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+FROM rust:1.85-bullseye
+
+# Install curl
+RUN apt update \
+    && apt install -y \
+    curl \
+    git \
+    software-properties-common \
+    vim \
+    jq
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B \
+    && add-apt-repository 'deb [arch=amd64,arm64] https://pkg.osquery.io/deb deb main'
+
+# Install osquery
+RUN apt update -y && apt install -y osquery
+
+# Use the default osquery config
+RUN cp /opt/osquery/share/osquery/osquery.example.conf /etc/osquery/osquery.conf
+
+RUN osqueryctl start osquery
+
+# Install additional tools
+RUN rustup component add rustfmt clippy
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "Rust osquery Dev",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "dev",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "workspaceFolder": "/workspace",
+  "extensions": [
+    "rust-lang.rust-analyzer",
+    "tamasfe.even-better-toml",
+    "serayuzgur.crates"
+  ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    environment:
+      - RUST_BACKTRACE=1
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined


### PR DESCRIPTION
Hello,

I briefly toyed with using osquery-rust for an upcoming project, but I don't think it'll work out. I've prepared a few PRs to contribute back some of my minor changes. This PR introduces a devcontainer that works with RustRover (and should work with vscode).

When the devcontainer is up and running, you can run and debug the `table-proc-meminfo` example and query the table with these commands:

```bash
osqueryctl start osquery
osqueryi --connect /var/osquery/osquery.em "select * from proc_meminfo;"
```
